### PR TITLE
Tweak block size for lfs tests while on SCORPIO_FLASH.

### DIFF
--- a/tests/subsys/fs/littlefs/src/test_lfs_basic.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_basic.c
@@ -62,10 +62,23 @@ static int clean_statvfs(const struct fs_mount_t *mp)
 		 stat.f_bsize, stat.f_frsize, stat.f_blocks, stat.f_bfree);
 	zassert_equal(stat.f_bsize, 16,
 		      "bsize fail");
+#ifdef CONFIG_SCORPIO_FLASH
+    /* 
+     * Scorpio emulates flash using 512 byte blocks vs 4k blocks. 
+     * 512 blocksize * 128 blocks == 64k
+     * Silly that this is hardcoded.
+     */
+	zassert_equal(stat.f_frsize, 512,
+		      "frsize fail");
+	zassert_equal(stat.f_blocks, 128,
+		      "blocks fail");
+#else
+    /* 4k blocksize * 16 blocks == 64k */
 	zassert_equal(stat.f_frsize, 4096,
 		      "frsize fail");
 	zassert_equal(stat.f_blocks, 16,
 		      "blocks fail");
+#endif
 	zassert_equal(stat.f_bfree, stat.f_blocks - 2U,
 		      "bfree fail");
 

--- a/tests/subsys/fs/littlefs/src/test_util.c
+++ b/tests/subsys/fs/littlefs/src/test_util.c
@@ -38,6 +38,7 @@ void test_util_path_init_base(void)
 		      "bad mnt init return");
 	zassert_equal(strcmp(path.path, mnt.mnt_point), 0, "bad mnt init path");
 
+#ifndef CONFIG_SCORPIO_FLASH
 	if (IS_ENABLED(CONFIG_DEBUG)) {
 		struct fs_mount_t invalid = {
 			.mnt_point = "relative",
@@ -46,6 +47,14 @@ void test_util_path_init_base(void)
 		/* Apparently no way to verify this without panic. */
 		testfs_path_init(&path, &invalid, TESTFS_PATH_END);
 	}
+#else
+   /* This is a lame test that checks for leading slash in pathname
+    * and actually asserts the machine when things are CORRECT if CONFIG_DEBUG is set.
+    * Since we run with CONFIG_DEBUG, we assert (even when correct).
+    *  
+    * Skip this for scorpio.
+    */
+#endif
 }
 
 void test_util_path_init_overrun(void)


### PR DESCRIPTION
  * Also skip leading slash test